### PR TITLE
Close figures when done, consolidate requirements

### DIFF
--- a/dooble/render.py
+++ b/dooble/render.py
@@ -95,3 +95,4 @@ def render_to_file(marble, filename, theme):
 
     ax.set_axis_off()
     plt.savefig(filename, dpi=fig.dpi)
+    plt.close()


### PR DESCRIPTION
Hi Romain,

I noticed that sphinx on the RxPY codebase is emitting warnings about too many open figures -- and it seems to me they can simply be closed after writing to disk.

~~Also, I think it makes sense to have requirements.txt be the primary source of truth about dependencies, and then read them into setup.py.~~
EDIT: Hmm it seems that doesn't work with tox, I've removed that commit. Sorry.

I really hope you don't mind my meddling with your repositories like this... If you do please just let me know.

And before I forget, great work on this marbles stuff!!