### PR TITLE
Accept more chars in description regexp

### DIFF
--- a/dooble/idl.py
+++ b/dooble/idl.py
@@ -32,7 +32,7 @@ grammar = '''
     item = /[a-zA-Z0-9+.,]+/ ;
 
 
-    description = /[a-zA-Z0-9,:+*() <>_{}=-]+/ ;
+    description = /[a-zA-Z0-9,:+*() <>_{}=$\/-]+/ ;
 '''
 
 

--- a/dooble/idl.py
+++ b/dooble/idl.py
@@ -32,7 +32,7 @@ grammar = '''
     item = /[a-zA-Z0-9+.,]+/ ;
 
 
-    description = /[a-zA-Z0-9,:+*() <>_]+/ ;
+    description = /[a-zA-Z0-9,:+*() <>_{}=-]+/ ;
 '''
 
 


### PR DESCRIPTION
This is to make it possible to use Dooble with other programming languages such as F# and C#. Would be nice if I could use it for [Elmish.Streams](https://elmish-streams.readthedocs.io/en/latest/). Fixes #7 